### PR TITLE
時間関連ツールを追加してUTCタイムスタンプ処理を改善

### DIFF
--- a/scripts/generate-tools.js
+++ b/scripts/generate-tools.js
@@ -609,10 +609,19 @@ async function generateTools() {
         }
       }
     }
-
+    // 既存のtimeディレクトリから時間関連ツールのパスを取得
+    let existingTimePaths = [];
+    const timeDir = path.join(__dirname, "../tools/time");
+    if (fs.existsSync(timeDir)) {
+      const timeFiles = fs.readdirSync(timeDir)
+        .filter(file => file.endsWith('.js'))
+        .map(file => `time/${file}`);
+      existingTimePaths = timeFiles;
+    }
     // paths.jsファイルの更新
     const pathsContent = `export const toolPaths = [
-${toolPaths.map((path) => `  '${path}'`).join(",\n")}
+${toolPaths.map((path) => `  '${path}'`).join(",\n")}${existingTimePaths.length > 0 ? ',' : ''}
+${existingTimePaths.map((path) => `  '${path}'`).join(",\n")}
 ];
 `;
 

--- a/tools/paths.js
+++ b/tools/paths.js
@@ -171,5 +171,7 @@ export const toolPaths = [
   'saasus-platform/pricingapi/createmeteringunit.js',
   'saasus-platform/pricingapi/getmeteringunits.js',
   'saasus-platform/pricingapi/updatemeteringunitbyid.js',
-  'saasus-platform/pricingapi/deletemeteringunitbyid.js'
+  'saasus-platform/pricingapi/deletemeteringunitbyid.js',
+  'time/calculaterelativetime.js',
+  'time/getcurrenttime.js'
 ];

--- a/tools/time/calculaterelativetime.js
+++ b/tools/time/calculaterelativetime.js
@@ -1,0 +1,90 @@
+/**
+ * Calculate Relative Time
+ * Calculate UTC timestamp for a relative time from now.
+ */
+const calculateRelativeTime = async (args) => {
+  const { 
+    offset_minutes = 0, 
+    offset_hours = 0, 
+    offset_days = 0,
+    reset_seconds = false,
+    reset_milliseconds = false
+  } = args;
+  
+  const now = new Date();
+  
+  // Reset seconds and milliseconds if specified
+  if (reset_seconds || reset_milliseconds) {
+    if (reset_seconds) {
+      now.setSeconds(0);
+    }
+    if (reset_milliseconds) {
+      now.setMilliseconds(0);
+    }
+  }
+  
+  const totalMinutes = offset_minutes + (offset_hours * 60) + (offset_days * 24 * 60);
+  const targetTime = new Date(now.getTime() + (totalMinutes * 60 * 1000));
+  
+  const utcTimestamp = Math.floor(targetTime.getTime() / 1000);
+  const utcISO = targetTime.toISOString();
+  
+  return {
+    utc_timestamp: utcTimestamp,
+    utc_iso: utcISO,
+    utc_formatted: targetTime.toUTCString(),
+    offset_minutes: totalMinutes,
+    calculation: `Current time plus ${totalMinutes} minutes`,
+    original_offsets: {
+      minutes: offset_minutes,
+      hours: offset_hours,
+      days: offset_days
+    },
+    time_adjustments: {
+      seconds_reset: reset_seconds,
+      milliseconds_reset: reset_milliseconds
+    }
+  };
+};
+
+/**
+ * ツール設定
+ */
+const apiTool = {
+  function: calculateRelativeTime,
+  definition: {
+    type: 'function',
+    function: {
+      name: 'calculaterelativetime',
+      description: `Calculate Relative Time: Calculate UTC timestamp for a relative time from now.`,
+      parameters: {
+        type: 'object',
+        properties: {
+          offset_minutes: {
+            type: 'number',
+            description: 'Minutes to add to current time (default: 0)'
+          },
+          offset_hours: {
+            type: 'number',
+            description: 'Hours to add to current time (default: 0)'
+          },
+          offset_days: {
+            type: 'number',
+            description: 'Days to add to current time (default: 0)'
+          },
+          reset_seconds: {
+            type: 'boolean',
+            description: 'Reset seconds to 0 (default: false)'
+          },
+          reset_milliseconds: {
+            type: 'boolean',
+            description: 'Reset milliseconds to 0 (default: false)'
+          }
+        },
+        required: []
+      }
+    }
+  }
+};
+
+export { apiTool };

--- a/tools/time/getcurrenttime.js
+++ b/tools/time/getcurrenttime.js
@@ -1,0 +1,40 @@
+/**
+ * Get Current Time
+ * Get the current UTC time in multiple formats.
+ */
+const getCurrentTime = async () => {
+  const now = new Date();
+  const utcTimestamp = Math.floor(now.getTime() / 1000);
+  const utcISO = now.toISOString();
+  const jstTime = new Date(now.getTime() + (9 * 60 * 60 * 1000)).toISOString(); // JST (UTC+9)
+  
+  return {
+    utc_timestamp: utcTimestamp,
+    utc_iso: utcISO,
+    jst_iso: jstTime,
+    utc_formatted: now.toUTCString(),
+    jst_formatted: new Date(now.getTime() + (9 * 60 * 60 * 1000)).toUTCString().replace('GMT', 'JST'),
+    unix_timestamp: now.getTime()
+  };
+};
+
+/**
+ * ツール設定
+ */
+const apiTool = {
+  function: getCurrentTime,
+  definition: {
+    type: 'function',
+    function: {
+      name: 'getcurrenttime',
+      description: `Get Current Time: Get the current UTC time in multiple formats.`,
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: []
+      }
+    }
+  }
+};
+
+export { apiTool };


### PR DESCRIPTION
AIがMCPサーバーを使用する際に、自然言語での日時指定（例：「現在時刻から5分後」）を正確にUTCタイムスタンプに変換できない問題を解決するため、時間関連ツールを追加しました。
