### PR TITLE
feat: CI/CD workflows と npm publish 設定の追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx eslint .

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,6 @@ jobs:
           node-version: 20
           registry-url: https://registry.npmjs.org
       - run: npm ci
-      - run: npm publish --provenance --access public
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish to npm
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,5 +5,5 @@ import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.browser } },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.node } },
 ]);

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import { Command } from "commander";
 import { registerToolsCommand } from "./commands/tools.js";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "postman-agent-generator-mcp",
+  "name": "saasus-api-mcp-server",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "postman-agent-generator-mcp",
+      "name": "saasus-api-mcp-server",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "js-yaml": "^4.1.0"
       },
       "bin": {
-        "saasus-api-mcp-server": "index.js"
+        "saasus-api-mcp-server": "mcpServer.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "express": "^5.1.0",
         "js-yaml": "^4.1.0"
       },
+      "bin": {
+        "saasus-api-mcp-server": "index.js"
+      },
       "devDependencies": {
         "@eslint/js": "^9.27.0",
         "eslint": "^9.27.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "postman-agent-generator-mcp",
+  "name": "saasus-api-mcp-server",
   "version": "1.0.0",
   "description": "A simple MCP server with packaged tools",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "A simple MCP server with packaged tools",
   "main": "index.js",
+  "bin": {
+    "saasus-api-mcp-server": "./index.js"
+  },
   "type": "module",
   "scripts": {
     "list-tools": "node index.js tools"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple MCP server with packaged tools",
   "main": "index.js",
   "bin": {
-    "saasus-api-mcp-server": "./index.js"
+    "saasus-api-mcp-server": "./mcpServer.js"
   },
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## 概要

CI/CD パイプラインと npm publish に必要な設定を追加します。

## 変更内容

- **`.github/workflows/ci.yml`** — push/PR 時に ESLint を実行する CI ワークフロー
- **`.github/workflows/publish.yml`** — GitHub Release 作成時に npm publish を自動実行する CD ワークフロー
- **`package.json`** — `bin` フィールドを追加（`npx saasus-api-mcp-server` で実行可能に）
- **`index.js`** — shebang (`#!/usr/bin/env node`) を追加

## npm publish の事前準備

1. npmjs.com で Automation タイプのアクセストークンを発行
2. GitHub リポジトリの Settings → Secrets → `NPM_TOKEN` として登録
3. package.json の `name` を公開用の名前に変更（必要に応じて）